### PR TITLE
Support Python 3.7

### DIFF
--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -69,6 +69,7 @@ class IsUtilityTestCase(TestCase):
 
 class GetUtilityTestCase(TestCase):
 
+    @skipIf(NEW_TYPING, "Not supported in Python 3.7")
     def test_last_origin(self):
         T = TypeVar('T')
         self.assertEqual(get_last_origin(int), None)
@@ -121,6 +122,7 @@ class GetUtilityTestCase(TestCase):
         self.assertEqual(get_args(int), ())
 
     def test_args_evaluated(self):
+        T = TypeVar('T')
         self.assertEqual(get_args(Union[int, Tuple[T, int]][str], evaluate=True),
                          (int, Tuple[str, int]))
         self.assertEqual(get_args(Dict[int, Tuple[T, T]][Optional[int]], evaluate=True),

--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -99,7 +99,7 @@ class GetUtilityTestCase(TestCase):
         self.assertEqual(get_parameters(Union[S_co, Tuple[T, T]][int, U]), (U,))
         self.assertEqual(get_parameters(Mapping[T, Tuple[S_co, T]]), (T, S_co))
 
-    @skipIf(NEW_TYPING)
+    @skipIf(NEW_TYPING, "Not supported in Python 3.7")
     def test_last_args(self):
         T = TypeVar('T')
         S = TypeVar('S')
@@ -111,7 +111,7 @@ class GetUtilityTestCase(TestCase):
         self.assertEqual(get_last_args(Callable[[T, S], int]), (T, S, int))
         self.assertEqual(get_last_args(Callable[[], int]), (int,))
 
-    @skipIf(NEW_TYPING)
+    @skipIf(NEW_TYPING, "Not supported in Python 3.7")
     def test_args(self):
         T = TypeVar('T')
         self.assertEqual(get_args(Union[int, Tuple[T, int]][str]),

--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -85,7 +85,7 @@ class GetUtilityTestCase(TestCase):
         self.assertEqual(get_origin(ClassVar[int]), None)
         self.assertEqual(get_origin(Generic), Generic)
         self.assertEqual(get_origin(Generic[T]), Generic)
-        self.assertEqual(get_origin(List[Tuple[T, T]][int]), List)
+        self.assertEqual(get_origin(List[Tuple[T, T]][int]), list if NEW_TYPING else List)
 
     def test_parameters(self):
         T = TypeVar('T')

--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -3,11 +3,14 @@ from typing_inspect import (
     is_typevar, is_classvar, get_origin, get_parameters, get_last_args, get_args,
     get_generic_type, get_generic_bases, get_last_origin,
 )
-from unittest import TestCase, main
+from unittest import TestCase, main, skipIf
 from typing import (
     Union, ClassVar, Callable, Optional, TypeVar, Sequence, Mapping,
     MutableMapping, Iterable, Generic, List, Any, Dict, Tuple, NamedTuple,
 )
+
+import sys
+NEW_TYPING = sys.version_info[:3] >= (3, 7, 0)  # PEP 560
 
 
 class IsUtilityTestCase(TestCase):
@@ -96,6 +99,7 @@ class GetUtilityTestCase(TestCase):
         self.assertEqual(get_parameters(Union[S_co, Tuple[T, T]][int, U]), (U,))
         self.assertEqual(get_parameters(Mapping[T, Tuple[S_co, T]]), (T, S_co))
 
+    @skipIf(NEW_TYPING)
     def test_last_args(self):
         T = TypeVar('T')
         S = TypeVar('S')
@@ -107,6 +111,7 @@ class GetUtilityTestCase(TestCase):
         self.assertEqual(get_last_args(Callable[[T, S], int]), (T, S, int))
         self.assertEqual(get_last_args(Callable[[], int]), (int,))
 
+    @skipIf(NEW_TYPING)
     def test_args(self):
         T = TypeVar('T')
         self.assertEqual(get_args(Union[int, Tuple[T, int]][str]),
@@ -114,6 +119,8 @@ class GetUtilityTestCase(TestCase):
         self.assertEqual(get_args(Union[int, Union[T, int], str][int]),
                          (int, str))
         self.assertEqual(get_args(int), ())
+
+    def test_args_evaluated(self):
         self.assertEqual(get_args(Union[int, Tuple[T, int]][str], evaluate=True),
                          (int, Tuple[str, int]))
         self.assertEqual(get_args(Dict[int, Tuple[T, T]][Optional[int]], evaluate=True),

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -51,7 +51,9 @@ def is_generic_type(tp):
         is_generic_type(Sequence[Union[str, bytes]]) == True
     """
     if NEW_TYPING:
-        return isinstance(tp, type) and issubclass(tp, Generic) or isinstance(tp, _GenericAlias)
+        return (isinstance(tp, type) and issubclass(tp, Generic) or
+                isinstance(tp, _GenericAlias) and tp.__origin__ not in (Union, tuple, ClassVar,
+                                                                        collections.abc.Callable))
     return (isinstance(tp, GenericMeta) and not
             isinstance(tp, (CallableMeta, TupleMeta)))
 

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -14,7 +14,9 @@ if NEW_TYPING:
 
 
 if NEW_TYPING:
-    from typing import Generic, Callable, Union, TypeVar, ClassVar, Tuple, _GenericAlias
+    from typing import (
+        Generic, Callable, Union, TypeVar, ClassVar, Tuple, _GenericAlias
+    )
 else:
     from typing import (
         Callable, CallableMeta, Union, _Union, TupleMeta, TypeVar,
@@ -52,8 +54,8 @@ def is_generic_type(tp):
     """
     if NEW_TYPING:
         return (isinstance(tp, type) and issubclass(tp, Generic) or
-                isinstance(tp, _GenericAlias) and tp.__origin__ not in (Union, tuple, ClassVar,
-                                                                        collections.abc.Callable))
+                isinstance(tp, _GenericAlias) and
+                tp.__origin__ not in (Union, tuple, ClassVar, collections.abc.Callable))
     return (isinstance(tp, GenericMeta) and not
             isinstance(tp, (CallableMeta, TupleMeta)))
 
@@ -75,11 +77,13 @@ def is_callable_type(tp):
     For more general tests use callable(), for more precise test
     (excluding subclasses) use::
 
-        get_origin(tp) is Callable
+        get_origin(tp) is collections.abc.Callable  # Callable prior to Python 3.7
     """
     if NEW_TYPING:
-        return (tp is Callable or isinstance(tp, _GenericAlias) and tp.__origin__ is collections.abc.Callable or
-                isinstance(tp, type) and issubclass(tp, Generic) and issubclass(tp, collections.abc.Callable))
+        return (tp is Callable or isinstance(tp, _GenericAlias) and
+                tp.__origin__ is collections.abc.Callable or
+                isinstance(tp, type) and issubclass(tp, Generic) and
+                issubclass(tp, collections.abc.Callable))
     return type(tp) is CallableMeta
 
 
@@ -99,11 +103,13 @@ def is_tuple_type(tp):
     For more general tests use issubclass(..., tuple), for more precise test
     (excluding subclasses) use::
 
-        get_origin(tp) is Tuple
+        get_origin(tp) is tuple  # Tuple prior to Python 3.7
     """
     if NEW_TYPING:
-        return (tp is Tuple or isinstance(tp, _GenericAlias) and tp.__origin__ is tuple or
-                isinstance(tp, type) and issubclass(tp, Generic) and issubclass(tp, tuple))
+        return (tp is Tuple or isinstance(tp, _GenericAlias) and
+                tp.__origin__ is tuple or
+                isinstance(tp, type) and issubclass(tp, Generic) and
+                issubclass(tp, tuple))
     return type(tp) is TupleMeta
 
 
@@ -116,7 +122,8 @@ def is_union_type(tp):
         is_union_type(Union[T, int]) == True
     """
     if NEW_TYPING:
-        return tp is Union or isinstance(tp, _GenericAlias) and tp.__origin__ is Union
+        return (tp is Union or
+                isinstance(tp, _GenericAlias) and tp.__origin__ is Union)
     return type(tp) is _Union
 
 
@@ -140,7 +147,8 @@ def is_classvar(tp):
         is_classvar(ClassVar[List[T]]) == True
     """
     if NEW_TYPING:
-        return tp is ClassVar or isinstance(tp, _GenericAlias) and tp.__origin__ is ClassVar
+        return (tp is ClassVar or
+                isinstance(tp, _GenericAlias) and tp.__origin__ is ClassVar)
     return type(tp) is _ClassVar
 
 
@@ -157,7 +165,8 @@ def get_last_origin(tp):
         get_last_origin(List) == List
     """
     if NEW_TYPING:
-        raise ValueError('This function is only supported in Python 3.6, use get_origin instead')
+        raise ValueError('This function is only supported in Python 3.6,'
+                         ' use get_origin instead')
     sentinel = object()
     origin = getattr(tp, '__origin__', sentinel)
     if origin is sentinel:
@@ -176,7 +185,7 @@ def get_origin(tp):
         get_origin(Generic) == Generic
         get_origin(Generic[T]) == Generic
         get_origin(Union[T, int]) == Union
-        get_origin(List[Tuple[T, T]][int]) == List
+        get_origin(List[Tuple[T, T]][int]) == list  # List prior to Python 3.7
     """
     if NEW_TYPING:
         if isinstance(tp, _GenericAlias):
@@ -208,7 +217,9 @@ def get_parameters(tp):
         get_parameters(Mapping[T, Tuple[S_co, T]]) == (T, S_co)
     """
     if NEW_TYPING:
-        if isinstance(tp, _GenericAlias) or isinstance(tp, type) and issubclass(tp, Generic) and tp is not Generic:
+        if (isinstance(tp, _GenericAlias) or
+            isinstance(tp, type) and issubclass(tp, Generic) and
+            tp is not Generic):
             return tp.__parameters__
         return ()
     if (
@@ -232,7 +243,8 @@ def get_last_args(tp):
         get_last_args(Callable[[], int]) == (int,)
     """
     if NEW_TYPING:
-        raise ValueError('This function is only supported in Python 3.6, use get_args instead')
+        raise ValueError('This function is only supported in Python 3.6,'
+                         ' use get_args instead')
     if is_classvar(tp):
         return (tp.__type__,) if tp.__type__ is not None else ()
     if (

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -294,7 +294,7 @@ def get_args(tp, evaluate=None):
         get_args(Callable[[], T][int], evaluate=True) == ([], int,)
     """
     if NEW_TYPING:
-        if evaluare is not None and not evaluate:
+        if evaluate is not None and not evaluate:
             raise ValueError('evaluate can only be True in Python 3.7')
         if isinstance(tp, _GenericAlias):
             res = tp.__args__

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -204,7 +204,7 @@ def get_parameters(tp):
         get_parameters(Mapping[T, Tuple[S_co, T]]) == (T, S_co)
     """
     if NEW_TYPING:
-        if isinstance(tp, _GenericAlias) or issubclass(tp, Generic):
+        if isinstance(tp, _GenericAlias) or issubclass(tp, Generic) and tp is not Generic:
             return tp.__parameters__
         return ()
     if (

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -76,7 +76,8 @@ def is_callable_type(tp):
         get_origin(tp) is Callable
     """
     if NEW_TYPING:
-        return tp is Callable or isinstance(tp, _GenericAlias) and tp.__origin__ is collections.abc.Callable
+        return (tp is Callable or isinstance(tp, _GenericAlias) and tp.__origin__ is collections.abc.Callable or
+                isinstance(tp, type) and issubclass(tp, Generic) and issubclass(tp, collections.abc.Callable))
     return type(tp) is CallableMeta
 
 
@@ -99,7 +100,8 @@ def is_tuple_type(tp):
         get_origin(tp) is Tuple
     """
     if NEW_TYPING:
-        return tp is Tuple or isinstance(tp, _GenericAlias) and tp.__origin__ is tuple
+        return (tp is Tuple or isinstance(tp, _GenericAlias) and tp.__origin__ is tuple or
+                isinstance(tp, type) and issubclass(tp, Generic) and issubclass(tp, tuple))
     return type(tp) is TupleMeta
 
 

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -8,13 +8,13 @@ Example usage::
 # NOTE: This module must support Python 2.7 in addition to Python 3.x
 
 import sys
-import collections.abc
-
 NEW_TYPING = sys.version_info[:3] >= (3, 7, 0)  # PEP 560
+if NEW_TYPING:
+    import collections.abc
 
 
 if NEW_TYPING:
-    from typing import Callable, Union, TypeVar, ClassVar, Tuple, _GenericAlias
+    from typing import Generic, Callable, Union, TypeVar, ClassVar, Tuple, _GenericAlias
 else:
     from typing import (
         Callable, CallableMeta, Union, _Union, TupleMeta, TypeVar,

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -176,7 +176,7 @@ def get_origin(tp):
     """
     if NEW_TYPING:
         if isinstance(tp, _GenericAlias):
-            return tp.__origin__
+            return tp.__origin__ if tp.__origin__ is not ClassVar else None
         if tp is Generic:
             return Generic
         return None
@@ -204,7 +204,7 @@ def get_parameters(tp):
         get_parameters(Mapping[T, Tuple[S_co, T]]) == (T, S_co)
     """
     if NEW_TYPING:
-        if isinstance(tp, _GenericAlias) or issubclass(tp, Generic) and tp is not Generic:
+        if isinstance(tp, _GenericAlias) or isinstance(tp, type) and issubclass(tp, Generic) and tp is not Generic:
             return tp.__parameters__
         return ()
     if (
@@ -281,7 +281,10 @@ def get_args(tp, evaluate=None):
         if not evaluate:
             raise ValueError('evaluate can only be True in Python 3.7')
         if isinstance(tp, _GenericAlias):
-            return tp.__args__
+            res = tp.__args__
+            if get_origin(tp) is collections.abc.Callable and res[0] is not Ellipsis:
+                res = (list(res[:-1]), res[-1])
+            return res
         return ()
     if is_classvar(tp):
         return (tp.__type__,)

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -51,7 +51,7 @@ def is_generic_type(tp):
         is_generic_type(Sequence[Union[str, bytes]]) == True
     """
     if NEW_TYPING:
-        return isinstance(tp, Generic) or isinstance(tp, _GenericAlias)
+        return isinstance(tp, type) and issubclass(tp, Generic) or isinstance(tp, _GenericAlias)
     return (isinstance(tp, GenericMeta) and not
             isinstance(tp, (CallableMeta, TupleMeta)))
 

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -294,7 +294,7 @@ def get_args(tp, evaluate=None):
         get_args(Callable[[], T][int], evaluate=True) == ([], int,)
     """
     if NEW_TYPING:
-        if not evaluate:
+        if evaluare is not None and not evaluate:
             raise ValueError('evaluate can only be True in Python 3.7')
         if isinstance(tp, _GenericAlias):
             res = tp.__args__

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -278,7 +278,7 @@ def get_args(tp, evaluate=None):
         get_args(Callable[[], T][int], evaluate=True) == ([], int,)
     """
     if NEW_TYPING:
-        if evaluate=False:
+        if not evaluate:
             raise ValueError('evaluate can only be True in Python 3.7')
         if isinstance(tp, _GenericAlias):
             return tp.__args__

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -257,11 +257,13 @@ def _eval_args(args):
     return tuple(res)
 
 
-def get_args(tp, evaluate=False):
+def get_args(tp, evaluate=None):
     """Get type arguments with all substitutions performed. For unions,
     basic simplifications used by Union constructor are performed.
-    If `evaluate` is False (default), report result as nested tuple, this matches
-    the internal representation of types. If `evaluate` is True, then all
+    On versions prior to 3.7 if `evaluate` is False (default),
+    report result as nested tuple, this matches
+    the internal representation of types. If `evaluate` is True
+    (or if Python version is 3.7 or greater), then all
     type parameters are applied (this could be time and memory expensive).
     Examples::
 
@@ -276,6 +278,8 @@ def get_args(tp, evaluate=False):
         get_args(Callable[[], T][int], evaluate=True) == ([], int,)
     """
     if NEW_TYPING:
+        if evaluate=False:
+            raise ValueError('evaluate can only be True in Python 3.7')
         if isinstance(tp, _GenericAlias):
             return tp.__args__
         return ()


### PR DESCRIPTION
Fixes #17 

This adds support for upcoming Python 3.7. The `typing` module in this version was thoroughly reworked, but I tried to keep semantics as much close to the previous versions as possible.