### PR TITLE
Add (very) simple support for TypedDict keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,5 @@ Currently provided functions (see functions docstrings for examples of usage):
   Get the generic type of ``obj`` if possible, or its runtime class otherwise.
 * ``get_generic_bases(tp)``:
   Get generic base types of ``tp`` or empty tuple if not possible.
+* ``typed_dict_keys(td)``:
+  Get ``TypedDict`` keys and their types, or None if ``td`` is not a typed dict.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 typing >= 3.6.1
+mypy_extensions >= 0.3.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ flake8; python_version >= '3.6'
 flake8-bugbear; python_version >= '3.6'
 pytest>=2.8; python_version >= '3.3'
 typing >= 3.6.1
+mypy_extensions >= 0.3.0

--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -1,7 +1,7 @@
 from typing_inspect import (
     is_generic_type, is_callable_type, is_tuple_type, is_union_type,
     is_typevar, is_classvar, get_origin, get_parameters, get_last_args, get_args,
-    get_generic_type, get_generic_bases, get_last_origin,
+    get_generic_type, get_generic_bases, get_last_origin, typed_dict_keys,
 )
 from unittest import TestCase, main, skipIf
 from typing import (
@@ -11,6 +11,8 @@ from typing import (
 
 import sys
 NEW_TYPING = sys.version_info[:3] >= (3, 7, 0)  # PEP 560
+
+from mypy_extensions import TypedDict
 
 
 class IsUtilityTestCase(TestCase):
@@ -142,6 +144,18 @@ class GetUtilityTestCase(TestCase):
         self.assertEqual(get_generic_bases(MyClass),
                          (List[int], Mapping[str, List[int]]))
         self.assertEqual(get_generic_bases(int), ())
+
+    def test_typed_dict(self):
+        class TD(TypedDict):
+            x: int
+            y: int
+        class Other(dict):
+            x: int
+            y: int
+
+        self.assertEqual(typed_dict_keys(TD), {'x': int, 'y': int})
+        self.assertIs(typed_dict_keys(dict), None)
+        self.assertIs(typed_dict_keys(Other), None)
 
 
 if __name__ == '__main__':

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -24,6 +24,9 @@ else:
     )
 
 
+from mypy_extensions import _TypedDictMeta
+
+
 def _gorg(cls):
     """This function exists for compatibility with old typing versions."""
     assert isinstance(cls, GenericMeta)
@@ -346,3 +349,23 @@ def get_generic_bases(tp):
     """
 
     return getattr(tp, '__orig_bases__', ())
+
+
+def typed_dict_keys(td):
+    """If td is a TypedDict class, return a dictionary mapping the typed keys to types.
+    Otherwise, return None. Examples::
+
+        class TD(TypedDict):
+            x: int
+            y: int
+        class Other(dict):
+            x: int
+            y: int
+
+        typed_dict_keys(TD) == {'x': int, 'y': int}
+        typed_dict_keys(dict) == None
+        typed_dict_keys(Other) == None
+    """
+    if isinstance(td, _TypedDictMeta):
+        return td.__annotations__.copy()
+    return None


### PR DESCRIPTION
Fixes #19 

Unfortunately, the current API doesn't allow reliably infer whether a given key is required or not.