### PR TITLE
Support Literal (PEP 586)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-typing >= 3.6.1
+typing >= 3.7.4
 mypy_extensions >= 0.3.0
 typing_extensions >= 3.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 typing >= 3.6.1
 mypy_extensions >= 0.3.0
+typing_extensions >= 3.7.4

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ classifiers = [
 
 install_requires = [
     'mypy_extensions >= 0.3.0',
-    'typing >= 3.6.1;python_version<"3.5"',
+    'typing >= 3.7.4;python_version<"3.5"',
     'typing_extensions >= 3.7.4',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ classifiers = [
 
 install_requires = [
     'mypy_extensions >= 0.3.0',
-    'typing >= 3.6.1;python_version<"3.5"'
+    'typing >= 3.6.1;python_version<"3.5"',
+    'typing_extensions >= 3.7.4',
 ]
 
 setup(

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 flake8; python_version >= '3.6'
 flake8-bugbear; python_version >= '3.6'
 pytest>=2.8; python_version >= '3.3'
-typing >= 3.6.1
+typing >= 3.7.4
 mypy_extensions >= 0.3.0
 typing_extensions >= 3.7.4

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ flake8-bugbear; python_version >= '3.6'
 pytest>=2.8; python_version >= '3.3'
 typing >= 3.6.1
 mypy_extensions >= 0.3.0
+typing_extensions >= 3.7.4

--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -111,7 +111,6 @@ class IsUtilityTestCase(TestCase):
         ]
         self.sample_test(is_literal_type, samples, nonsamples)
 
-
     def test_typevar(self):
         T = TypeVar('T')
         S_co = TypeVar('S_co', covariant=True)

--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -1,7 +1,7 @@
 from typing_inspect import (
     is_generic_type, is_callable_type, is_tuple_type, is_union_type,
-    is_optional_type, is_typevar, is_classvar, get_origin, get_parameters,
-    get_last_args, get_args, get_bound, get_constraints, get_generic_type,
+    is_optional_type, is_literal_type, is_typevar, is_classvar, get_origin,
+    get_parameters, get_last_args, get_args, get_bound, get_constraints, get_generic_type,
     get_generic_bases, get_last_origin, typed_dict_keys,
 )
 from unittest import TestCase, main, skipIf, skipUnless
@@ -14,6 +14,7 @@ import sys
 NEW_TYPING = sys.version_info[:3] >= (3, 7, 0)  # PEP 560
 
 from mypy_extensions import TypedDict
+from typing_extensions import Literal
 
 PY36_TESTS = """
 class TD(TypedDict):
@@ -95,6 +96,22 @@ class IsUtilityTestCase(TestCase):
                        ]
         self.sample_test(is_optional_type, samples, nonsamples)
 
+    def test_literal_type(self):
+        samples = [
+            Literal,
+            Literal["v"],
+            Literal[1, 2, 3],
+        ]
+        nonsamples = [
+            "v",
+            (1, 2, 3),
+            int,
+            str,
+            Union["u", "v"],
+        ]
+        self.sample_test(is_literal_type, samples, nonsamples)
+
+
     def test_typevar(self):
         T = TypeVar('T')
         S_co = TypeVar('S_co', covariant=True)
@@ -172,6 +189,11 @@ class GetUtilityTestCase(TestCase):
         self.assertEqual(get_args(Callable[[], T][int], evaluate=True), ([], int,))
         self.assertEqual(get_args(Union[int, Callable[[Tuple[T, ...]], str]], evaluate=True),
                          (int, Callable[[Tuple[T, ...]], str]))
+
+        # Literal special-casing
+        self.assertEqual(get_args(Literal, evaluate=True), ())
+        self.assertEqual(get_args(Literal["value"], evaluate=True), ("value",))
+        self.assertEqual(get_args(Literal[1, 2, 3], evaluate=True), (1, 2, 3))
 
     def test_bound(self):
         T = TypeVar('T')

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -17,11 +17,16 @@ if NEW_TYPING:
     from typing import (
         Generic, Callable, Union, TypeVar, ClassVar, Tuple, _GenericAlias
     )
+    from typing_extensions import Literal
 else:
     from typing import (
         Callable, CallableMeta, Union, _Union, TupleMeta, TypeVar,
         _ClassVar, GenericMeta,
     )
+    try:  # python 3.6
+        from typing_extensions import _Literal
+    except ImportError:  # python 2.7
+        from typing import _Literal
 
 
 from mypy_extensions import _TypedDictMeta
@@ -149,6 +154,13 @@ def is_union_type(tp):
         return (tp is Union or
                 isinstance(tp, _GenericAlias) and tp.__origin__ is Union)
     return type(tp) is _Union
+
+
+def is_literal_type(tp):
+    if NEW_TYPING:
+        return (tp is Literal or
+                isinstance(tp, _GenericAlias) and tp.__origin__ is Literal)
+    return type(tp) is _Literal
 
 
 def is_typevar(tp):
@@ -329,6 +341,8 @@ def get_args(tp, evaluate=None):
         return ()
     if is_classvar(tp):
         return (tp.__type__,)
+    if is_literal_type(tp):
+        return tp.__values__ or ()
     if (
         is_generic_type(tp) or is_union_type(tp) or
         is_callable_type(tp) or is_tuple_type(tp)


### PR DESCRIPTION
Adds an `is_literal_type` API, and fixes `get_args` for literal types on 3.6 and 2.7 (provided by `typing_extensions`).

[This feature is in 3.8](https://www.python.org/dev/peps/pep-0586/), but it's available as a backport to 3.7 and below as part of [`typing_extensions`](https://github.com/python/typing/tree/master/typing_extensions), so this adds `typing_extensions` as a dependency.

I've tested this pull request by running the unit tests against Python 2.7, 3.6, and 3.7.