### PR TITLE
Fix get_args for unparameterized ClassVar on <3.7

### DIFF
--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -173,6 +173,10 @@ class GetUtilityTestCase(TestCase):
         self.assertEqual(get_args(Union[int, Callable[[Tuple[T, ...]], str]], evaluate=True),
                          (int, Callable[[Tuple[T, ...]], str]))
 
+        # ClassVar special-casing
+        self.assertEqual(get_args(ClassVar, evaluate=True), ())
+        self.assertEqual(get_args(ClassVar[int], evaluate=True), (int,))
+
     def test_bound(self):
         T = TypeVar('T')
         TB = TypeVar('TB', bound=int)

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -328,7 +328,7 @@ def get_args(tp, evaluate=None):
             return res
         return ()
     if is_classvar(tp):
-        return (tp.__type__,)
+        return (tp.__type__,) if tp.__type__ is not None else ()
     if (
         is_generic_type(tp) or is_union_type(tp) or
         is_callable_type(tp) or is_tuple_type(tp)


### PR DESCRIPTION
In 3.7, `get_args(ClassVar)` (no parameter specified) would return an empty tuple. In 3.6 it would return `(None,)` because `__type__` is `None` in that case.

This copies the logic that already existed in `get_last_args` to normalize that case to an empty tuple.

I've tested this pull request by running the unit tests against Python 2.7, 3.6, and 3.7.