### PR TITLE
Account for Py 3.8 in "get_args" ValueError

### DIFF
--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -330,7 +330,7 @@ def get_args(tp, evaluate=None):
     """
     if NEW_TYPING:
         if evaluate is not None and not evaluate:
-            raise ValueError('evaluate can only be True in Python 3.7')
+            raise ValueError('evaluate can only be True in Python >= 3.7')
         if isinstance(tp, _GenericAlias):
             res = tp.__args__
             if get_origin(tp) is collections.abc.Callable and res[0] is not Ellipsis:


### PR DESCRIPTION
With introduction of Python 3.8 `get_args` `ValueError` message omits mentioning that `evaluate` can be `True` for `Python >= (3, 7, 0)` as derived from `NEW_TYPING` const.