### PR TITLE
Change 3.8-dev to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 python:
-  - "3.8-dev"
+  - "3.8"
   - "3.7"
   - "3.6"
   - "3.5"


### PR DESCRIPTION
Python 3.8 is present for a while now. Use stable release.