### PR TITLE
Adding function `is_forward_ref`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 tmp/
 *.swp
 *.pyc
+venv/

--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -247,11 +247,10 @@ class IsUtilityTestCase(TestCase):
         samples = []
         nonsamples = []
         for tp in (
-            Union["FowardReference", Dict],
-            Union["FR", List],
+            Union["FowardReference", Dict[str, List[int]]],
+            Union["FR", Union[int, str]],
             Optional["Fref"],
             Union["fRef", int],
-            Union["fr", str],
             Union["fR", AnyStr],
         ):
             fr, not_fr = get_args(tp)

--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -4,7 +4,7 @@ from typing_inspect import (
     is_optional_type, is_literal_type, is_typevar, is_classvar, is_forward_ref,
     get_origin, get_parameters, get_last_args, get_args, get_bound, get_constraints,
     get_generic_type, get_generic_bases, get_last_origin, typed_dict_keys,
-    WITH_LITERAL, LEGACY_TYPING)
+    get_forward_arg, WITH_LITERAL, LEGACY_TYPING)
 from unittest import TestCase, main, skipIf, skipUnless
 from typing import (
     Union, Callable, Optional, TypeVar, Sequence, AnyStr, Mapping,
@@ -405,6 +405,17 @@ class GetUtilityTestCase(TestCase):
         self.assertIs(typed_dict_keys(dict), None)
         self.assertIs(typed_dict_keys(Other), None)
         self.assertIsNot(typed_dict_keys(TD), TD.__annotations__)
+
+    @skipIf(
+        (3, 5, 2) > sys.version_info[:3] >= (3, 5, 0),
+        "get_args doesn't work in Python 3.5.0 and 3.5.1 for type"
+        " List and ForwardRef arg"
+    )
+    def test_get_forward_arg(self):
+        tp = List["FRef"]
+        fr = get_args(tp)[0]
+        self.assertEqual(get_forward_arg(fr), "FRef")
+        self.assertEqual(get_forward_arg(tp), None)
 
 
 if __name__ == '__main__':

--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -1,13 +1,13 @@
 import sys
 from typing_inspect import (
     is_generic_type, is_callable_type, is_new_type, is_tuple_type, is_union_type,
-    is_optional_type, is_literal_type, is_typevar, is_classvar, get_origin,
-    get_parameters, get_last_args, get_args, get_bound, get_constraints,
+    is_optional_type, is_literal_type, is_typevar, is_classvar, is_forward_ref,
+    get_origin, get_parameters, get_last_args, get_args, get_bound, get_constraints,
     get_generic_type, get_generic_bases, get_last_origin, typed_dict_keys,
     WITH_LITERAL, LEGACY_TYPING)
 from unittest import TestCase, main, skipIf, skipUnless
 from typing import (
-    Union, Callable, Optional, TypeVar, Sequence, Mapping,
+    Union, Callable, Optional, TypeVar, Sequence, AnyStr, Mapping,
     MutableMapping, Iterable, Generic, List, Any, Dict, Tuple, NamedTuple,
 )
 
@@ -242,6 +242,22 @@ class IsUtilityTestCase(TestCase):
             T,
         ]
         self.sample_test(is_new_type, samples, nonsamples)
+
+    def test_is_forward_ref(self):
+        samples = []
+        nonsamples = []
+        for tp in (
+            Union["FowardReference", Dict],
+            Union["FR", List],
+            Optional["Fref"],
+            Union["fRef", int],
+            Union["fr", str],
+            Union["fR", AnyStr],
+        ):
+            fr, not_fr = get_args(tp)
+            samples.append(fr)
+            nonsamples.append(not_fr)
+        self.sample_test(is_forward_ref, samples, nonsamples)
 
 
 class GetUtilityTestCase(TestCase):

--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -248,7 +248,7 @@ class IsUtilityTestCase(TestCase):
         nonsamples = []
         for tp in (
             Union["FowardReference", Dict[str, List[int]]],
-            Union["FR", Union[int, str]],
+            Union["FR", List["FR"]],
             Optional["Fref"],
             Union["fRef", int],
             Union["fR", AnyStr],

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -552,6 +552,19 @@ def typed_dict_keys(td):
     return None
 
 
+def get_forward_arg(fr):
+    """
+    If fr is a ForwardRef, return the string representation of the forward reference.
+    Otherwise return None. Examples::
+
+        tp = List["FRef"]
+        fr = get_args(tp)[0]
+        get_forward_arg(fr) == "FRef"
+        get_forward_arg(tp) == None
+    """
+    return fr.__forward_arg__ if is_forward_ref(fr) else None
+
+
 # A few functions backported and adapted for the LEGACY_TYPING context, and used above
 
 def _replace_arg(arg, tvars, args):

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -20,12 +20,12 @@ LEGACY_TYPING = False
 
 if NEW_TYPING:
     from typing import (
-        Generic, Callable, Union, TypeVar, ClassVar, Tuple, _GenericAlias
+        Generic, Callable, Union, TypeVar, ClassVar, Tuple, _GenericAlias, ForwardRef
     )
     from typing_extensions import Literal
 else:
     from typing import (
-        Callable, CallableMeta, Union, Tuple, TupleMeta, TypeVar, GenericMeta,
+        Callable, CallableMeta, Union, Tuple, TupleMeta, TypeVar, GenericMeta, _ForwardRef
     )
     try:
         from typing import _Union, _ClassVar
@@ -537,6 +537,14 @@ def typed_dict_keys(td):
     if isinstance(td, _TypedDictMeta):
         return td.__annotations__.copy()
     return None
+
+def is_forward_ref(tp):
+    """
+    Returns True if ``tp`` is a :class:`typing.ForwardRef` or False otherwise.
+    """
+    if not NEW_TYPING:
+        return isinstance(tp, _ForwardRef)
+    return isinstance(tp, ForwardRef)
 
 
 # A few functions backported and adapted for the LEGACY_TYPING context, and used above

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -213,6 +213,19 @@ def is_new_type(tp):
     return getattr(tp, '__supertype__', None) is not None
 
 
+def is_forward_ref(tp):
+    """Tests if the type is a :class:`typing.ForwardRef`. Examples::
+
+        u = Union["Milk", Way]
+        args = get_args(u)
+        is_forward_ref(args[0]) == True
+        is_forward_ref(args[1]) == False
+    """
+    if not NEW_TYPING:
+        return isinstance(tp, _ForwardRef)
+    return isinstance(tp, ForwardRef)
+
+
 def get_last_origin(tp):
     """Get the last base of (multiply) subscripted type. Supports generic types,
     Union, Callable, and Tuple. Returns None for unsupported types.
@@ -537,14 +550,6 @@ def typed_dict_keys(td):
     if isinstance(td, _TypedDictMeta):
         return td.__annotations__.copy()
     return None
-
-def is_forward_ref(tp):
-    """
-    Returns True if ``tp`` is a :class:`typing.ForwardRef` or False otherwise.
-    """
-    if not NEW_TYPING:
-        return isinstance(tp, _ForwardRef)
-    return isinstance(tp, ForwardRef)
 
 
 # A few functions backported and adapted for the LEGACY_TYPING context, and used above


### PR DESCRIPTION
 - Adds function ``is_forward_ref`` which tests if ``tp`` is a :class:`typing.ForwardRef`.
- Adds function ``get_forward_arg`` which returns the string representation of the forward reference.