### PR TITLE
Support Final (PEP 591)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Currently provided functions (see functions docstrings for examples of usage):
   Test if ``tp`` is a union type.
 * ``is_optional_type(tp)``:
   Test if ``tp`` is an optional type (either ``type(None)`` or a direct union to it such as in ``Optional[int]``). Nesting and ``TypeVar``s are not unfolded/inspected in this process.
+* ``is_final_type(tp)``:
+  Test if ``tp`` is a final type.
 * ``is_typevar(tp)``:
   Test if ``tp`` represents a type variable.
 * ``is_new_type(tp)``:

--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -1,10 +1,10 @@
 import sys
 from typing_inspect import (
     is_generic_type, is_callable_type, is_new_type, is_tuple_type, is_union_type,
-    is_optional_type, is_literal_type, is_typevar, is_classvar, is_forward_ref,
-    get_origin, get_parameters, get_last_args, get_args, get_bound, get_constraints,
-    get_generic_type, get_generic_bases, get_last_origin, typed_dict_keys,
-    get_forward_arg, WITH_LITERAL, LEGACY_TYPING)
+    is_optional_type, is_final_type, is_literal_type, is_typevar, is_classvar,
+    is_forward_ref, get_origin, get_parameters, get_last_args, get_args, get_bound,
+    get_constraints, get_generic_type, get_generic_bases, get_last_origin,
+    typed_dict_keys, get_forward_arg, WITH_FINAL, WITH_LITERAL, LEGACY_TYPING)
 from unittest import TestCase, main, skipIf, skipUnless
 from typing import (
     Union, Callable, Optional, TypeVar, Sequence, AnyStr, Mapping,
@@ -13,6 +13,7 @@ from typing import (
 
 from mypy_extensions import TypedDict as METypedDict
 from typing_extensions import TypedDict as TETypedDict
+from typing_extensions import Final
 from typing_extensions import Literal
 
 # Does this raise an exception ?
@@ -195,6 +196,22 @@ class IsUtilityTestCase(TestCase):
                        ]
         self.sample_test(is_optional_type, samples, nonsamples)
 
+    @skipIf(not WITH_FINAL, "Final is not available")
+    def test_final_type(self):
+        samples = [
+            Final,
+            Final[int],
+        ]
+        nonsamples = [
+            "v",
+            1,
+            (1, 2, 3),
+            int,
+            str,
+            Union["u", "v"],
+        ]
+        self.sample_test(is_final_type, samples, nonsamples)
+
     @skipIf(not WITH_LITERAL, "Literal is not available")
     def test_literal_type(self):
         samples = [
@@ -362,6 +379,11 @@ class GetUtilityTestCase(TestCase):
         if WITH_CLASSVAR:
             self.assertEqual(get_args(ClassVar, evaluate=True), ())
             self.assertEqual(get_args(ClassVar[int], evaluate=True), (int,))
+
+        # Final special-casing
+        if WITH_FINAL:
+            self.assertEqual(get_args(Final, evaluate=True), ())
+            self.assertEqual(get_args(Final[int], evaluate=True), (int,))
 
         # Literal special-casing
         if WITH_LITERAL:


### PR DESCRIPTION
This PR adds an `is_final_type` function and extends `get_args` to support `Final` type. Supported Python versions are 2.7 and 3.6+ (via `typing_extensions` before 3.8).

Closes #61.