### PR TITLE
import typing._TypedDictMeta in Python 3.9

### DIFF
--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -11,6 +11,9 @@ import sys
 from mypy_extensions import _TypedDictMeta as _TypedDictMeta_Mypy
 if sys.version_info[:3] >= (3, 4, 0) and sys.version_info[:3] < (3, 9, 0):
     from typing_extensions import _TypedDictMeta as _TypedDictMeta_TE
+elif sys.version_info[:3] >= (3, 9, 0):
+    # typing_extensions.TypedDict is a re-export from typing.
+    from typing import _TypedDictMeta as _TypedDictMeta_TE
 else:
     # typing_extensions.TypedDict is a re-export from typing.
     from typing import TypedDict


### PR DESCRIPTION
`typing_extensions` just re-exports `typing` in Python3.9. `type(typing.TypedDict)` is just a function in Python3.9, just as in `typing_extensions`.

Fixes #65