### PR TITLE
Require newer typing-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 typing >= 3.7.4
 mypy_extensions >= 0.3.0
-typing_extensions >= 3.7.4
+typing_extensions >= 3.7.4.2


### PR DESCRIPTION
I think we need at least 3.7.4.2 these days.

Under 3.4.7.1, I get this error during import:
```
  File ".../typing_inspect.py", line 17, in <module>
    from typing_extensions import _TypedDictMeta as _TypedDictMeta_TE
ImportError: cannot import name '_TypedDictMeta' from 'typing_extensions' 
```