### PR TITLE
Making the is_new_type check more robust then just checking __supertype__ existance

### DIFF
--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -34,7 +34,8 @@ LEGACY_TYPING = False
 
 if NEW_TYPING:
     from typing import (
-        Generic, Callable, Union, TypeVar, ClassVar, Tuple, _GenericAlias, ForwardRef
+        Generic, Callable, Union, TypeVar, ClassVar, Tuple, _GenericAlias,
+        ForwardRef, NewType,
     )
     from typing_extensions import Final, Literal
     if sys.version_info[:3] >= (3, 9, 0):
@@ -44,7 +45,8 @@ if NEW_TYPING:
         typingGenericAlias = (_GenericAlias,)
 else:
     from typing import (
-        Callable, CallableMeta, Union, Tuple, TupleMeta, TypeVar, GenericMeta, _ForwardRef
+        Callable, CallableMeta, Union, Tuple, TupleMeta, TypeVar, GenericMeta,
+        _ForwardRef, NewType,
     )
     try:
         from typing import _Union, _ClassVar
@@ -247,10 +249,17 @@ def is_new_type(tp):
     """Tests if the type represents a distinct type. Examples::
 
         is_new_type(int) == False
+        is_new_type(NewType) == True
         is_new_type(NewType('Age', int)) == True
         is_new_type(NewType('Scores', List[Dict[str, float]])) == True
     """
-    return getattr(tp, '__supertype__', None) is not None
+    if sys.version_info[:3] >= (3, 10, 0) and sys.version_info.releaselevel != 'beta':
+        return tp is NewType or isinstance(tp, NewType)
+    else:
+        return (tp is NewType or
+                (getattr(tp, '__supertype__', None) is not None and
+                 getattr(tp, '__qualname__', '') == 'NewType.<locals>.new_type' and
+                 tp.__module__ == 'typing'))
 
 
 def is_forward_ref(tp):


### PR DESCRIPTION

Currently everthing which has an attribute called `__supertype__`
will be accepted as ‚NewType‘ according to the function `is_new_type`.

I find that a bit dangerous, since a user might expect that `is_new_type` is as reliant as a `isinstance` call.
For example, these are false positives:

```
>>>> import typing_inspect
>>>> class MyClassWrapper:
....     def __init__(self):
....         self.__supertype__ = 'foobar'
....         
>>>> mcw = MyClassWrapper()
>>>> typing_inspect.is_new_type(mcw)
True
```

```
>>>> class MyClassWrapper:
....     __supertype__ = str
....     
>>>> typing_inspect.is_new_type(MyClassWrapper)
True
```

We cannot do an `isinstance` check because NewType is a function, but we can add more conditions, which makes it harder for an false positive:

Now with this MR it is additionally checked that the `__qualname__` must be
'NewType.<locals>.new_type', and that the module where the symbol is
defined has the name 'typing'. A user could still fullfill all those
conditions in a custom class, but the probability bacame quite low (espacially if it is not on purpose).

Furtheremore support for python 3.10¹, where NewType is not a function
any more but a class, is added. This check is implemented by
isincance() and should work always correctly.

The symbol `NewType` (i.e. *not* the call if it `NewType()`) is now also cosidered as
a NewType by doing a `tp is NewType` check. This is in alignment with
other functions, such as `is_classvar()` which does an `tp is ClassVar`
or `is_union_type()` which do a `tp is Union`.

¹ To be specific, the first RC of python 3.10, i.e. in all bata
versions NewType is still a function. Please also note that the class
NewType in python 3.10.0rc has a different `__qualname__` then the
function NewType before.