### PR TITLE
provide compatibility for any python>=3.9

### DIFF
--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -12,10 +12,10 @@ import types
 
 from mypy_extensions import _TypedDictMeta as _TypedDictMeta_Mypy
 
-# See comments in typing_extensions source on why the switch is at 3.9.2
-if (3, 4, 0) <= sys.version_info[:3] < (3, 9, 2):
+# See comments in typing_extensions source on why the switch is at 3.9
+if (3, 4, 0) <= sys.version_info[:3] < (3, 9):
     from typing_extensions import _TypedDictMeta as _TypedDictMeta_TE
-elif sys.version_info[:3] >= (3, 9, 2):
+elif sys.version_info[:3] >= (3, 9):
     # typing_extensions.TypedDict is a re-export from typing.
     from typing import _TypedDictMeta as _TypedDictMeta_TE
 else:


### PR DESCRIPTION
Hi!

I'm currently working off of `python3.9.1` and running into issues when using `typing_inspect`. Those issues are resolved by relaxing the constraint from 3.9.2 to 3.9. 

I believe it's okay to relax this constraint, because I explored the referenced source code -- `typing_extensions` and found all of their most stringent constraints to be for 3.9, not 3.9.2. 

