### PR TITLE
Make `get_origin(Literal[...]) == Literal`.

### DIFF
--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -337,6 +337,8 @@ class GetUtilityTestCase(TestCase):
             self.assertEqual(get_origin(ClassVar[int]), None)
         self.assertEqual(get_origin(Generic), Generic)
         self.assertEqual(get_origin(Generic[T]), Generic)
+        # Cannot use assertEqual on Py3.5.2.
+        self.assertIs(get_origin(Literal[42]), Literal)
         if PY39:
             self.assertEqual(get_origin(list[int]), list)
         if GENERIC_TUPLE_PARAMETRIZABLE:

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -66,10 +66,10 @@ else:
             WITH_FINAL = False
 
     try:  # python 3.6
-        from typing_extensions import _Literal
+        from typing_extensions import Literal
     except ImportError:  # python 2.7
         try:
-            from typing import _Literal
+            from typing import Literal
         except ImportError:
             WITH_LITERAL = False
 
@@ -230,7 +230,7 @@ def is_literal_type(tp):
     if NEW_TYPING:
         return (tp is Literal or
                 isinstance(tp, typingGenericAlias) and tp.__origin__ is Literal)
-    return WITH_LITERAL and type(tp) is _Literal
+    return WITH_LITERAL and type(tp) is type(Literal)
 
 
 def is_typevar(tp):
@@ -345,6 +345,8 @@ def get_origin(tp):
         return Union
     if is_tuple_type(tp):
         return Tuple
+    if is_literal_type(tp):
+        return Literal
 
     return None
 


### PR DESCRIPTION
See https://github.com/ilevkivskyi/typing_inspect/pull/39#issuecomment-907637313.