### PR TITLE
Handle non-indexed generics >= py3.9

### DIFF
--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -14,6 +14,7 @@ from typing import (
     Union, Callable, Optional, TypeVar, Sequence, AnyStr, Mapping,
     MutableMapping, Iterable, Generic, List, Any, Dict, Tuple, NamedTuple,
 )
+from typing import T as typing_T
 
 from mypy_extensions import TypedDict as METypedDict
 from typing_extensions import TypedDict as TETypedDict
@@ -357,7 +358,7 @@ class GetUtilityTestCase(TestCase):
             if PY39:
                 self.assertEqual(get_parameters(List), ())
             else:
-                self.assertEqual(get_parameters(List), (T,))
+                self.assertEqual(get_parameters(List), (typing_T,))
         else:
             # in 3.5.3 a list has no __args__ and instead they are used in __parameters__
             # in 3.5.1 the behaviour is normal again.

--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -354,6 +354,10 @@ class GetUtilityTestCase(TestCase):
         self.assertEqual(get_parameters(Union), ())
         if not LEGACY_TYPING:
             self.assertEqual(get_parameters(List[int]), ())
+            if PY39:
+                self.assertEqual(get_parameters(List), ())
+            else:
+                self.assertEqual(get_parameters(List), (T,))
         else:
             # in 3.5.3 a list has no __args__ and instead they are used in __parameters__
             # in 3.5.1 the behaviour is normal again.

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -408,7 +408,11 @@ def get_parameters(tp):
         else:
             return ()
     elif NEW_TYPING:
-        if (isinstance(tp, typingGenericAlias) or
+        if (
+                (
+                    isinstance(tp, typingGenericAlias) and
+                    hasattr(tp, '__parameters__')
+                ) or
                 isinstance(tp, type) and issubclass(tp, Generic) and
                 tp is not Generic):
             return tp.__parameters__


### PR DESCRIPTION
Closes #93 
This prevents `get_parameters` throwing an exception on python >= 3.9. 
This does lead to a difference in behaviour between different python versions, but the new class based alias introduced in 3.9 doesn't store the required info. So to maintaining the same behaviour would require a dictionary of the generic types to the correct output.

Example of change in behaviour:
**python <=3.8**
```
>>> from typing import List
>>> from typing_inspect import get_parameters
>>> get_parameters(List)
(~T,)
```

**python >=3.9**
```
>>> from typing import List
>>> from typing_inspect import get_parameters
>>> get_parameters(List)
()
```