### PR TITLE
Support types.UnionType in get_parameters()

### DIFF
--- a/test_typing_inspect.py
+++ b/test_typing_inspect.py
@@ -4,7 +4,7 @@ import typing
 import pytest
 
 from typing_inspect import (
-    is_generic_type, is_callable_type, is_new_type, is_tuple_type, is_union_type,
+    WITH_PIPE_UNION, is_generic_type, is_callable_type, is_new_type, is_tuple_type, is_union_type,
     is_optional_type, is_final_type, is_literal_type, is_typevar, is_classvar,
     is_forward_ref, get_origin, get_parameters, get_last_args, get_args, get_bound,
     get_constraints, get_generic_type, get_generic_bases, get_last_origin,
@@ -379,6 +379,9 @@ class GetUtilityTestCase(TestCase):
         self.assertEqual(get_parameters(Mapping[T, Tuple[S_co, T]]), (T, S_co))
         if PY39:
             self.assertEqual(get_parameters(dict[int, T]), (T,))
+        if WITH_PIPE_UNION:
+            self.assertEqual(get_parameters(int | str), ())
+            self.assertEqual(get_parameters(int | list[T]), (T,))
 
     @skipIf(NEW_TYPING, "Not supported in Python 3.7")
     def test_last_args(self):

--- a/typing_inspect.py
+++ b/typing_inspect.py
@@ -33,6 +33,9 @@ else:
 NEW_TYPING = sys.version_info[:3] >= (3, 7, 0)  # PEP 560
 if NEW_TYPING:
     import collections.abc
+WITH_PIPE_UNION = sys.version_info[:3] >= (3, 10, 0)  # PEP 604
+if WITH_PIPE_UNION:
+    from types import UnionType
 
 WITH_FINAL = True
 WITH_LITERAL = True
@@ -430,6 +433,7 @@ def get_parameters(tp):
                     isinstance(tp, typingGenericAlias) and
                     hasattr(tp, '__parameters__')
                 ) or
+                (WITH_PIPE_UNION and isinstance(tp, UnionType)) or
                 isinstance(tp, type) and issubclass(tp, Generic) and
                 tp is not Generic):
             return tp.__parameters__


### PR DESCRIPTION
This fixes a test on Python 3.14 because there Union[] also creates instances
of types.UnionType.
